### PR TITLE
Add nowallet option - bitcoind using disablewallet=1 config

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -38,24 +38,25 @@ type (
 	// Bitcoind config
 	// NOTE: Keep in mind that this is **not yet encrypted**, so best to keep it _local_
 	Bitcoind struct {
-		Host string `toml:"host"`
-		Port int64  `toml:"port"`
-		User string `toml:"user"`
-		Pass string `toml:"pass"`
+		Host     string `toml:"host"`
+		Port     int64  `toml:"port"`
+		User     string `toml:"user"`
+		Pass     string `toml:"pass"`
+		NoWallet bool   `toml:"nowallet"`
 	}
 
 	// Lnd config
 	Lnd struct {
-		Host      string `toml:"host"`
-		Port      int64  `toml:"port"`
+		Host string `toml:"host"`
+		Port int64  `toml:"port"`
 
 		// TLS certificate is usually located in `~/.lnd/tls.cert`
-		Tls       string `toml:"tls"`
+		Tls string `toml:"tls"`
 
 		// Macaroons are usually located in `~/.lnd/data/chain/bitcoin/mainnet/`
 		Macaroons struct {
 			// This is needed to generate new invoices
-			Invoice  string `toml:"invoice"`
+			Invoice string `toml:"invoice"`
 
 			// This is needed to check status of invoices (and if enabled access `/history` endpoint)
 			ReadOnly string `toml:"readonly"`

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/lncm/invoicer/bitcoind"
-	"github.com/lncm/invoicer/clightning"
+	cLightning "github.com/lncm/invoicer/clightning"
 	"github.com/lncm/invoicer/common"
 	"github.com/lncm/invoicer/lnd"
 )
@@ -221,18 +221,21 @@ func newPayment(c *gin.Context) {
 			return
 		}
 
-		label := data.Description
-		if len(payment.Hash) > 0 {
-			label = payment.Hash
-		}
+		if conf.Bitcoind.NoWallet != true {
+			label := data.Description
+			if len(payment.Hash) > 0 {
+				label = payment.Hash
+			}
 
-		err = btcClient.ImportAddress(payment.Address, label)
-		if err != nil {
-			replyStatus(c, common.StatusReply{
-				Code:  500,
-				Error: fmt.Errorf("can't import address (%s) to Bitcoin node: %w", payment.Address, err).Error(),
-			})
-			return
+			err = btcClient.ImportAddress(payment.Address, label)
+			if err != nil {
+				replyStatus(c, common.StatusReply{
+					Code:  500,
+					Error: fmt.Errorf("can't import address (%s) to Bitcoin node: %w", payment.Address, err).Error(),
+				})
+				return
+			}
+
 		}
 	}
 


### PR DESCRIPTION
Hello,
I see a 500 HTTP error and bitcoind error when generating an on-chain payment address.

![bitcoind_error](https://user-images.githubusercontent.com/2481829/65663879-fb794d80-e005-11e9-9730-5b010e9bea97.png)

It's caused by the "disablewallet" option enabled on the bitcoind service. Since there is no wallet, the "btcClient.ImportAddress" call to the bitcoind service fails. A simple new configuration option allows the user to disable the bitcoind address import. 