### PR TITLE
Run as non-root user by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 #   Alpine and once on Debian.  After the build completes both binaries are compared.  If identical, the result
 #   binary is stripped, and moved to a final stage that's ready to be uploaded to Docker Hub or Github Registry.
 
+ARG USER=invoicer
+ARG DIR=/data/
+
 # This stage builds invoicer in an Alpine environment
 FROM golang:1.13-alpine3.11 AS alpine-builder
 
@@ -114,8 +117,8 @@ RUN du        /bin/invoicer
 #   which would break cross-compiled images.
 FROM alpine:3.11 AS perms
 
-ARG USER=invoicer
-ARG DIR=/data/
+ARG USER
+ARG DIR
 
 # NOTE: Default GID == UID == 1000
 RUN adduser --disabled-password \
@@ -127,8 +130,8 @@ RUN adduser --disabled-password \
 # This is a final stage, destined to be distributed, if successful
 FROM alpine:3.11 AS final
 
-ARG USER=invoicer
-ARG DIR=/data/
+ARG USER
+ARG DIR
 
 # Hai 👋
 LABEL maintainer="Damian Mee (@meeDamian)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,8 +114,7 @@ RUN du        /bin/invoicer
 #   which would break cross-compiled images.
 FROM alpine:3.11 AS perms
 
-# The most generic linux-native name for the user I could quickly come up with 🤷🏻‍♂️
-ARG USER=tux
+ARG USER=invoicer
 ARG DIR=/data/
 
 # NOTE: Default GID == UID == 1000
@@ -128,7 +127,7 @@ RUN adduser --disabled-password \
 # This is a final stage, destined to be distributed, if successful
 FROM alpine:3.11 AS final
 
-ARG USER=tux
+ARG USER=invoicer
 ARG DIR=/data/
 
 # Hai 👋

--- a/Dockerfile
+++ b/Dockerfile
@@ -154,3 +154,4 @@ WORKDIR ${DIR}
 # Specify the start command and entrypoint as the invoicer daemon.
 ENTRYPOINT ["invoicer"]
 
+CMD ["-config", "/data/invoicer.conf"]


### PR DESCRIPTION
This PR changes the image to run as an unprivileged user by default.  

I've tried to keep it simple, while also cross-compilation friendly.

Opinions?  I believe this scheme can be easily ported to https://github.com/lncm/docker-bitcoind & https://github.com/lncm/docker-lnd

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lncm/invoicer/48)
<!-- Reviewable:end -->
